### PR TITLE
docs: Fix typo in compiler build explanation

### DIFF
--- a/src/getting_grain.md
+++ b/src/getting_grain.md
@@ -21,7 +21,7 @@ yarn setup
 yarn compiler build
 ```
 
-Running `yarn setup` will set up the Grain runtime, standard library, and CLI, and `yarn compiler:build` will compile the compiler (it's pretty meta—we know).
+Running `yarn setup` will set up the Grain runtime, standard library, and CLI, and `yarn compiler build` will compile the compiler (it's pretty meta—we know).
 
 After running these commands, you've have two new commands available on your command line—`grainc` and `grain`. The `grainc` command is the standalone compiler, and the `grain` command is a CLI tool that both compiles and runs Grain programs. Throughout the guide, we'll mostly be using `grain`.
 


### PR DESCRIPTION
Forgot to update this in https://github.com/grain-lang/grain-lang.org/pull/71