### PR TITLE
Remove cmake requirement

### DIFF
--- a/src/getting_grain.md
+++ b/src/getting_grain.md
@@ -4,7 +4,7 @@ title: Getting Grain
 
 ## Building Grain
 
-To build the compiler, you'll need [Node.js](https://nodejs.org/en/download/current/) v14, [Yarn](https://yarnpkg.com/getting-started/install), and [CMake](https://cgold.readthedocs.io/en/latest/first-step/installation.html).
+To build the compiler, you'll need [Node.js](https://nodejs.org/en/download/current/) v14 and [Yarn](https://yarnpkg.com/getting-started/install).
 
 Start by cloning the Grain repository:
 


### PR DESCRIPTION
Once https://github.com/grain-lang/grain/pull/395 lands, we don't need people to install cmake first.