### PR TITLE
Document `Array.find` & `Array.findIndex`.

### DIFF
--- a/src/stdlib/array.md
+++ b/src/stdlib/array.md
@@ -145,10 +145,10 @@ Checks if the item is an element of the input array. Uses the generic `==` struc
 ### Array.**find**
 
 ```grain
-find : (a -> Bool, Array<a>) -> Number 
+find : (a -> Bool, Array<a>) -> a
 ```
 
-`Array.find(fn, array)` calls `fn` on each element of the array and returns the first element which matches the condition.
+`Array.find(fn, array)` calls `fn` on each element of the array and returns the first element for which `fn` returns `true`.
 
 ### Array.**findIndex**
 
@@ -156,4 +156,4 @@ find : (a -> Bool, Array<a>) -> Number
 find : (a -> Bool, Array<a>) -> Number 
 ```
 
-`Array.findIndex(fn, array)` calls `fn` on each element of the array and returns the index of the first element which matches the condition.
+`Array.findIndex(fn, array)` calls `fn` on each element of the array and returns the index of the first element for which `fn` returns `true`.

--- a/src/stdlib/array.md
+++ b/src/stdlib/array.md
@@ -153,7 +153,7 @@ find : (a -> Bool, Array<a>) -> a
 ### Array.**findIndex**
 
 ```grain
-find : (a -> Bool, Array<a>) -> Number 
+findIndex : (a -> Bool, Array<a>) -> Number 
 ```
 
 `Array.findIndex(fn, array)` calls `fn` on each element of the array and returns the index of the first element for which `fn` returns `true`.

--- a/src/stdlib/array.md
+++ b/src/stdlib/array.md
@@ -141,3 +141,19 @@ contains : (a, Array<a>) -> Bool
 ```
 
 Checks if the item is an element of the input array. Uses the generic `==` structural equality operator.
+
+### Array.**find**
+
+```grain
+find : (a -> Bool, Array<a>) -> Number 
+```
+
+`Array.find(fn, array)` calls `fn` on each element of the array and returns the first element which matches the condition.
+
+### Array.**findIndex**
+
+```grain
+find : (a -> Bool, Array<a>) -> Number 
+```
+
+`Array.findIndex(fn, array)` calls `fn` on each element of the array and returns the index of the first element which matches the condition.


### PR DESCRIPTION
This PR adds documentation for the `Array.find` & `Array.findIndex` functions.

Closes #118.