### PR TITLE
Fix syntax of isEven and isOdd example

### DIFF
--- a/src/constructs/bindings.md
+++ b/src/constructs/bindings.md
@@ -122,8 +122,8 @@ let rec isEven = (n) => {
   } else {
     n == 0
   }
-}
-and isOdd = (n) => {
+},
+isOdd = (n) => {
   if (n > 1) {
     isEven(n-1)
   } else {


### PR DESCRIPTION
I realized that this actually hasn't been valid syntax for quite some time.