### PR TITLE
Update banner to point to the wasm summit

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 </head>
 <body>
   <section class="site-banner">
-    Check Out Our Latest Updates—<a href="/blog/2020/09/29/grain-state-of-the-union-2020/">Grain State of the Union 2020</a>
+    Get an intro to Grain at the&nbsp;<a href="https://webassembly-summit.org/" target="_blank" rel="noopener">2021 WebAssembly Summit</a>
   </section>
   <section id="hero">
     <nav id="nav">


### PR DESCRIPTION
After the links to individual talks are live, we can update the banner again to point to that.