### PR TITLE
chore: Remove overview from constructs

### DIFF
--- a/docs_config.yml
+++ b/docs_config.yml
@@ -67,7 +67,6 @@ docs_groups:
     - stdlib/float32
     - stdlib/float64
   Language Constructs:
-    - constructs/overview
     - constructs/bindings
     - constructs/numbers
     - constructs/booleans

--- a/src/constructs/overview.md
+++ b/src/constructs/overview.md
@@ -1,7 +1,0 @@
----
-title: Overview
----
-
-## What Grain is All About
-
-This documentation hasn't yet been migrated here (or written, to be honest). In the meanwhile, please check out the [Grain compiler README](https://github.com/grain-lang/grain/blob/master/README.md) for more information. Consider contributing by fleshing out this page yourself!


### PR DESCRIPTION
This page was really old and doesn't really serve a purpose. Deleting it seems like the best thing to do.