### PR TITLE
Defer CSS loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
   </section>
   <section id="hero">
     <nav id="nav">
-      <a href="/"><img class="nav-logo" src="/images/grain_logo_white.svg"></a>
+      <a href="/"><img class="nav-logo" width="127" height="32" src="/images/grain_logo_white.svg"></a>
       <div class="nav-links">
         <a href="/docs" class="nav-link heading">Guide</a>
         <a href="/docs/intro" class="nav-link heading">Documentation</a>
@@ -65,7 +65,7 @@
       <a href="/blog" class="nav-link heading">Blog</a>
     </div>
     <div class="hero-content">
-      <img class="brand" src="/images/grain_shorthand_white.svg">
+      <img class="brand" width="192" height="206" src="/images/grain_shorthand_white.svg">
       <h1 class="hero-heading heading">A modern web staple.</h1>
       <h2 class="hero-heading2 heading">Grain is a new language that puts academic language features to work.</h2>
       <a href="/docs" class="button hero-cta">Let's Go</a>
@@ -118,7 +118,7 @@
     <a href="/docs" class="banner-cta button">Let's Go</a>
   </section>
   <footer class="footer">
-    <img src="/images/grain_shorthand_color.svg" alt="Grain shorthand" class="footer-logo">
+    <img width="64" height="68" src="/images/grain_shorthand_color.svg" alt="Grain shorthand" class="footer-logo">
     <div class="footer-links">
       <p class="footer-link-header">For Developers</p>
       <ul>

--- a/index.html
+++ b/index.html
@@ -33,8 +33,10 @@
   <meta name="msapplication-wide310x150logo" content="mstile-310x150.png" />
   <meta name="msapplication-square310x310logo" content="mstile-310x310.png" />
   <meta name="viewport" content="width=device-width,minimum-scale=1.0,initial-scale=1,user-scalable=yes">
-  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:600,700&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
+  <link rel="preload" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:600,700&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:600,700&display=swap"></noscript>
+  <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans"></noscript>
   <script src="https://kit.fontawesome.com/080d9b67ba.js" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="stylesheets/style.css" />
 </head>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:600,700&display=swap"></noscript>
   <link rel="preload" href="https://fonts.googleapis.com/css?family=Open+Sans" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans"></noscript>
-  <script src="https://kit.fontawesome.com/080d9b67ba.js" crossorigin="anonymous"></script>
+  <script async src="https://kit.fontawesome.com/080d9b67ba.js" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="stylesheets/style.css" />
 </head>
 <body>

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -14,6 +14,7 @@ html {
 
 html, body {
   font-family: "Open Sans", sans-serif;
+  font-display: fallback;
   color: var(--black);
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
@@ -172,6 +173,7 @@ html, body {
 .blurb-icon {
   color: var(--gray2);
   font-size: 4rem;
+  min-height: 4rem;
 }
 .blurb-title {
   font-size: 1.5rem;
@@ -316,7 +318,7 @@ html, body {
   .hide-mobile {
     display: none;
   }
-  
+
   .nav-links {
     display: none;
   }


### PR DESCRIPTION
It's a bit of a long story, but I was looking at the Google PageSpeed insights for Grain, and I saw that our mobile FCP rendering time was not stellar:
![image](https://user-images.githubusercontent.com/4998607/116819423-5a069600-ab70-11eb-8a3d-8a5ef1966a1f.png)

Looking at the opportunities identified by the tool, I saw that we are blocking the page renders on CSS loads (and FontAwesome):
![image](https://user-images.githubusercontent.com/4998607/116819458-773b6480-ab70-11eb-8104-42ca3627fb11.png)

This PR should defer those loads and hopefully allow the rendering to happen faster.