### PR TITLE
feat: Add styling for history details

### DIFF
--- a/themes/grain/source/css/style.scss
+++ b/themes/grain/source/css/style.scss
@@ -525,7 +525,7 @@ details {
     }
     > summary::marker,
     > summary::-webkit-details-marker {
-      color: var(--gray2);
+      color: var(--gray);
     }
   }
 }

--- a/themes/grain/source/css/style.scss
+++ b/themes/grain/source/css/style.scss
@@ -515,6 +515,21 @@ table {
   }
 }
 
+details {
+  margin: 0.5rem 0;
+  font-size: 1rem;
+
+  &[disabled] {
+    > summary {
+      pointer-events: none;
+    }
+    > summary::marker,
+    > summary::-webkit-details-marker {
+      color: var(--gray2);
+    }
+  }
+}
+
 pre {
   font-size: 95%;
   font-family: "Menlo", monospace;


### PR DESCRIPTION
Pulled this out of #240 - styling for the `<details>` blocks produced by graindoc.