### PR TITLE
feat: Add link to Discord in hero with other socials

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,7 @@
       <div class="footer-social-links">
         <a href="https://github.com/grain-lang/grain" class="footer-social-link"><i class="fab fa-github"></i></a>
         <a href="https://twitter.com/grain_lang" class="footer-social-link"><i class="fab fa-twitter"></i></a>
+        <a href="https://discord.com/invite/grain-lang" class="footer-social-link"><i class="fab fa-discord"></i></a>
       </div>
       <div class="made-by">
         <p>Made with <i class="fas fa-cocktail"></i> by the Grain core team <br class="hide-mobile">& Grain contributors</p>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@
       <div class="nav-social-links">
         <a href="https://github.com/grain-lang/grain" class="nav-link"><i class="fab fa-github nav-social-link"></i></a>
         <a href="https://twitter.com/grain_lang" class="nav-link"><i class="fab fa-twitter nav-social-link"></i></a>
+        <a href="https://discord.com/invite/grain-lang" class="nav-link"><i class="fab fa-discord nav-social-link"></i></a>
       </div>
     </nav>
     <div class="nav-links-mobile">

--- a/themes/grain/layout/_partial/footer.ejs
+++ b/themes/grain/layout/_partial/footer.ejs
@@ -20,6 +20,7 @@
     <div class="footer-social-links">
       <a href="https://github.com/grain-lang/grain" class="footer-social-link"><i class="fab fa-github"></i></a>
       <a href="https://twitter.com/grain_lang" class="footer-social-link"><i class="fab fa-twitter"></i></a>
+      <a href="https://discord.com/invite/grain-lang" class="footer-social-link"><i class="fab fa-discord"></i></a>
     </div>
     <div class="made-by">
       <p>Made with <i class="fas fa-cocktail"></i> by the Grain core team <br class="hide-mobile">& Grain contributors</p>

--- a/themes/grain/layout/_partial/hero.ejs
+++ b/themes/grain/layout/_partial/hero.ejs
@@ -17,6 +17,7 @@
     <div class="nav-social-links">
       <a href="https://github.com/grain-lang/grain" class="nav-link"><i class="fab fa-github nav-social-link"></i></a>
       <a href="https://twitter.com/grain_lang" class="nav-link"><i class="fab fa-twitter nav-social-link"></i></a>
+      <a href="https://discord.com/invite/grain-lang" class="nav-link"><i class="fab fa-discord nav-social-link"></i></a>
     </div>
   </nav>
 </section>


### PR DESCRIPTION
We can discuss whether this is a good change or not, but I thought it might be nice to have a link to the Discord page with the other socials in the header. Currently, there are two links to the Discord page: one mention in the docs, and a link if you scroll down on the homepage. This makes it much more prominent on the website.

Preview:

![image](https://user-images.githubusercontent.com/4998607/133121714-13daddbc-d21c-4b40-aa96-e0922028b42b.png)

Closes #185 .