### PR TITLE
feat: Add workflow to update website based on a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,21 @@ jobs:
           ref: ${{ github.event.inputs.tag }}
           path: grain
 
+      - name: Configure git
+        run: |
+          git config user.name grainbot[bot]
+          git config user.email bot@grain-lang.org
+
       - name: Copy stdlib docs
         run: |
           find grain/stdlib -name '*.md' | sed -E 's/grain\/stdlib//' | xargs -L 1 -I '{}' cp grain/stdlib/'{}' ./src/stdlib/'{}'
 
-      # GitHub Actions bot: https://github.community/t/github-actions-bot-email-address/17204/6
-      - name: Commit website updates
+      - name: Commit updates
         run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add src/getting_grain.md
           git add src/stdlib/
           git commit -m 'chore: Update website for ${{ github.event.inputs.tag }}'
+
+      - name: Push updates
+        run: |
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Copy stdlib docs
         run: |
-          find grain/stdlib -name '*.md' | sed -E 's/grain\/stdlib//' | xargs -L 1 -I '{}' cp grain/stdlib/'{}' ./src/stdlib/'{}'
+          find grain/stdlib -name '*.md' | sed -E 's|grain/stdlib/||' | xargs -L 1 -I '{}' cp 'grain/stdlib/{}' './src/stdlib/{}'
 
       - name: Commit updates
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Grain Release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "The tag of release"
+        required: true
+
+jobs:
+  release-updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+
+      - name: Replace download links
+        run: |
+          sed -E -i 's/(https:\/\/github\.com\/grain-lang\/grain\/releases\/download\/)[^\/]+(\/)/\1${{ github.event.inputs.tag }}\2/g' src/getting_grain.md
+
+      - name: Checkout Grain
+        uses: actions/checkout@v2
+        with:
+          repository: grain-lang/grain
+          ref: ${{ github.event.inputs.tag }}
+          path: grain
+
+      - name: Copy stdlib docs
+        run: |
+          find grain/stdlib -name '*.md' | sed -E 's/grain\/stdlib//' | xargs -L 1 -I '{}' cp grain/stdlib/'{}' ./src/stdlib/'{}'
+
+      # GitHub Actions bot: https://github.community/t/github-actions-bot-email-address/17204/6
+      - name: Commit website updates
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add src/getting_grain.md
+          git add src/stdlib/
+          git commit -m 'chore: Update website for ${{ github.event.inputs.tag }}'
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Replace download links
         run: |
-          sed -E -i 's/(https:\/\/github\.com\/grain-lang\/grain\/releases\/download\/)[^\/]+(\/)/\1${{ github.event.inputs.tag }}\2/g' src/getting_grain.md
+          sed -E -i 's|(https://github\.com/grain-lang/grain/releases/download/)[^/]+(/)|\1${{ github.event.inputs.tag }}\2|g' src/getting_grain.md
 
       - name: Checkout Grain
         uses: actions/checkout@v2

--- a/src/stdlib/.gitignore
+++ b/src/stdlib/.gitignore
@@ -1,0 +1,2 @@
+README.md
+CHANGELOG.md


### PR DESCRIPTION
This adds a workflow that is triggered by a [workflow_dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch) event, which is a manual event that can be triggered through the GitHub UI or via an API call. I plan to implement the API call into the release flow of the main Grain repo.

You can see my experiments with this at https://github.com/phated/grain-lang.org/commit/3acccdf14414e6284d470eb99011843dbf1bbd31 and https://github.com/phated/grain-lang.org/commit/13cf1d4d0afdf78e14a78f60d284f6575361147a (I just used tags that already existed so the diffs might look confusing - like going from v0.4.2 to v0.4.1 - but you can see how it works).