### PR TITLE
feat: Add Support For rss and atom

### DIFF
--- a/blog_config.yml
+++ b/blog_config.yml
@@ -17,6 +17,24 @@ root: /blog/
 permalink: :year/:month/:day/:title/
 permalink_defaults:
 
+# RSS Feed
+feed:
+  enable: true
+  type:
+    - atom
+    - rss2
+  path:
+    - atom.xml
+    - rss2.xml
+  limit: 20
+  hub:
+  content: true
+  content_limit: 140
+  content_limit_delim: ' '
+  order_by: -date
+  icon: ./../favicon/favicon.ico
+  autodiscovery: true
+  template:
 # Directory
 source_dir: src_blog
 public_dir: blog

--- a/package-lock.json
+++ b/package-lock.json
@@ -2111,6 +2111,15 @@
         }
       }
     },
+    "hexo-generator-feed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hexo-generator-feed/-/hexo-generator-feed-3.0.0.tgz",
+      "integrity": "sha512-Jo35VSRSNeMitS2JmjCq3OHAXXYU4+JIODujHtubdG/NRj2++b3Tgyz9pwTmROx6Yxr2php/hC8og5AGZHh8UQ==",
+      "requires": {
+        "hexo-util": "^2.1.0",
+        "nunjucks": "^3.0.0"
+      }
+    },
     "hexo-generator-index": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/hexo-generator-index/-/hexo-generator-index-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "hexo": "^4.2.1",
     "hexo-generator-archive": "^0.1.4",
     "hexo-generator-category": "^0.1.3",
+    "hexo-generator-feed": "^3.0.0",
     "hexo-generator-index": "^0.2.0",
     "hexo-generator-tag": "^0.2.0",
     "hexo-renderer-ejs": "^0.3.0",


### PR DESCRIPTION
Added support for an rss2 feed and atom feed using https://github.com/hexojs/hexo-generator-feed.
solves to #206.
Routes are:
https://grain-lang.org/blog/rss2.xml
https://grain-lang.org/blog/atom.xml