### PR TITLE
array: encourage use of List; show literal syntax

### DIFF
--- a/src/stdlib/array.md
+++ b/src/stdlib/array.md
@@ -2,7 +2,15 @@
 title: Array
 ---
 
-Utilities for working with arrays.
+Utilities for working with arrays. Array is a lower level implementation than [List](./list); prefer working with List. You can use [toList](#toList) and [fromList](#fromList) to easily convert an Array to/from a List.
+
+You can create an Array using Array literal syntax:
+
+```grain
+let array = [> 1, 2, 3]
+```
+
+Note the `>`! If you omit this, Grain will create a List.
 
 <details>
 <summary>Added in <code>0.2.0</code></summary>


### PR DESCRIPTION
I think this is a good start to a more useful intro to Array. I don't know enough about why I would use Array vs List to add that info myself, but I think it should be here and on the List page.