### PR TITLE
chore: Add docs for basic types

### DIFF
--- a/docs_config.yml
+++ b/docs_config.yml
@@ -46,7 +46,7 @@ docs_groups:
     - guide/imports_exports
   The Docs:
     - intro
-    - basic_types
+    - builtin_types
     - tooling/graindoc
   Standard Library:
     - stdlib/pervasives

--- a/docs_config.yml
+++ b/docs_config.yml
@@ -46,6 +46,7 @@ docs_groups:
     - guide/imports_exports
   The Docs:
     - intro
+    - basic_types
     - tooling/graindoc
   Standard Library:
     - stdlib/pervasives

--- a/src/basic_types.md
+++ b/src/basic_types.md
@@ -1,16 +1,8 @@
 ---
-title: Basic types
+title: Basic Types
 ---
 
 Grain provides some basic types to be used throughout your programs.
-
-### **Number**
-
-```grain
-type Number
-```
-
-The type of Grain numbers, i.e. `42`, `0x2a`. Grain numbers can be integers, floats, rationals, or "big integers".
 
 ### **Bool**
 
@@ -23,6 +15,14 @@ enum Bool {
 
 The type of Grain booleans, i.e. the type of `true` and `false`.
 
+### **Char**
+
+```grain
+type Char
+```
+
+The type of Grain Unicode characters, i.e. `'g'`, `'🌾'`, `'💻'`.
+
 ### **String**
 
 ```grain
@@ -30,6 +30,14 @@ type String
 ```
 
 The type of Grain strings, i.e. `"The quick brown fox jumps over the lazy dog."`.
+
+### **Bytes**
+
+```grain
+type Bytes
+```
+
+The type of Grain byte sequences.
 
 ### **Void**
 
@@ -39,7 +47,7 @@ enum Void {
 }
 ```
 
-The type of `void`, also known as "nothing".
+The type of `void`, also known as "unit" or "nothing".
 
 ### **Array**
 
@@ -56,3 +64,59 @@ type Box<a>
 ```
 
 The type of Grain boxes. Boxes are wrappers that allow the internal data to be swapped during execution.
+
+### **Number**
+
+```grain
+type Number
+```
+
+The type of Grain numbers, i.e. `42`, `0x2a`, `23.19`, `2/3`. Grain numbers can be arbitrarily large integers, floats, or rationals.
+
+### **BigInt**
+
+```grain
+type BigInt
+```
+
+The type of arbitrarily large integers, i.e. `42t`, `9_223_372_036_854_775_808t`.
+
+### **Int32**
+
+```grain
+type Int32
+```
+
+The type of 32-bit integers, i.e. `42l`, `0x2al`.
+
+### **Int64**
+
+```grain
+type Int64
+```
+
+The type of 64-bit integers, i.e. `42L`, `0x2aL`.
+
+### **Float32**
+
+```grain
+type Float32
+```
+
+The type of 32-bit floating-point numbers, i.e. `3.5f`.
+
+### **Float64**
+
+```grain
+type Float64
+```
+
+The type of 64-bit floating-point numbers, i.e. `3.5d`.
+
+### **Exception**
+
+```grain
+type Exception
+```
+
+The type of Grain exceptions. Exceptions represent errors that have occured in a program.

--- a/src/basic_types.md
+++ b/src/basic_types.md
@@ -1,0 +1,58 @@
+---
+title: Basic types
+---
+
+Grain provides some basic types to be used throughout your programs.
+
+### **Number**
+
+```grain
+type Number
+```
+
+The type of Grain numbers, i.e. `42`, `0x2a`. Grain numbers can be integers, floats, rationals, or "big integers".
+
+### **Bool**
+
+```grain
+enum Bool {
+  true,
+  false
+}
+```
+
+The type of Grain booleans, i.e. the type of `true` and `false`.
+
+### **String**
+
+```grain
+type String
+```
+
+The type of Grain strings, i.e. `"The quick brown fox jumps over the lazy dog."`.
+
+### **Void**
+
+```grain
+enum Void {
+  void
+}
+```
+
+The type of `void`, also known as "nothing".
+
+### **Array**
+
+```grain
+type Array<a>
+```
+
+The type of Grain arrays, i.e. `[> 1, 2, 3]`. Arrays are fixed-length and allow for efficient get/set operations at any index.
+
+### **Box**
+
+```grain
+type Box<a>
+```
+
+The type of Grain boxes. Boxes are wrappers that allow the internal data to be swapped during execution.

--- a/src/builtin_types.md
+++ b/src/builtin_types.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Types
+title: Built-in Types
 ---
 
 Grain provides some basic types to be used throughout your programs.

--- a/src/builtin_types.md
+++ b/src/builtin_types.md
@@ -2,7 +2,7 @@
 title: Built-in Types
 ---
 
-Grain provides some basic types to be used throughout your programs.
+Grain provides some built-in types to be used throughout your programs.
 
 ### **Bool**
 


### PR DESCRIPTION
Since these are part of the compiler, they aren't actually part of the stdlib (or Pervasives).