### PR TITLE
fix: Avoid shadowing concept in List guide

### DIFF
--- a/src/guide/lists.md
+++ b/src/guide/lists.md
@@ -17,8 +17,8 @@ let strings = ["foo", "bar", "baz"]
 Lists in Grain are linked lists, so if we'd like to add a new item to a list, we add it to the front:
 
 ```grain
-let pair = [2, 3]
-let triple = [1, ...pair]
+let twoThree = [2, 3]
+let oneTwoThree = [1, ...twoThree]
 
 print(triple) // [1, 2, 3]
 ```

--- a/src/guide/lists.md
+++ b/src/guide/lists.md
@@ -18,9 +18,9 @@ Lists in Grain are linked lists, so if we'd like to add a new item to a list, we
 
 ```grain
 let numbers = [2, 3]
-let numbers = [1, ...numbers]
+let numbers1 = [1, ...numbers]
 
-print(numbers) // [1, 2, 3]
+print(numbers1) // [1, 2, 3]
 ```
 
 We can also write functions that process data in lists, but we'll save that fun for the section on Pattern Matching.

--- a/src/guide/lists.md
+++ b/src/guide/lists.md
@@ -17,10 +17,10 @@ let strings = ["foo", "bar", "baz"]
 Lists in Grain are linked lists, so if we'd like to add a new item to a list, we add it to the front:
 
 ```grain
-let numbers = [2, 3]
-let numbers1 = [1, ...numbers]
+let pair = [2, 3]
+let triple = [1, ...pair]
 
-print(numbers1) // [1, 2, 3]
+print(triple) // [1, 2, 3]
 ```
 
 We can also write functions that process data in lists, but we'll save that fun for the section on Pattern Matching.

--- a/src/guide/lists.md
+++ b/src/guide/lists.md
@@ -20,7 +20,7 @@ Lists in Grain are linked lists, so if we'd like to add a new item to a list, we
 let twoThree = [2, 3]
 let oneTwoThree = [1, ...twoThree]
 
-print(triple) // [1, 2, 3]
+print(oneTwoThree) // [1, 2, 3]
 ```
 
 We can also write functions that process data in lists, but we'll save that fun for the section on Pattern Matching.


### PR DESCRIPTION
Usage of mutable variable before this concept is introduced gives a misleading impression of the language.