### PR TITLE
fix: Respond with the error message if the wasm run fails

### DIFF
--- a/playground_src/scripts/compiler.js
+++ b/playground_src/scripts/compiler.js
@@ -92,8 +92,8 @@ addEventListener("message", async ({ data }) => {
         wasi.start();
         postMessage({ stdout: processStdout(wasi.getStdoutString()) });
       } catch (err) {
-        // TODO: deal with err
-        console.log(err);
+        // TODO: deal with err better?
+        postMessage({ stderr: err.message });
       }
     } catch (err) {
       postMessage({ stderr: processStderr(stderr) });


### PR DESCRIPTION
I noticed that if I try to compile an empty file, it succeeds but then the WASI runner fails (which then makes the user unable to compile without a refresh).

This temporary fix at least responds with an error so the recompile can be performed.