### PR TITLE
chore: Add immutablemap & immutableset to sidebar

### DIFF
--- a/docs_config.yml
+++ b/docs_config.yml
@@ -62,7 +62,9 @@ docs_groups:
     - stdlib/float32
     - stdlib/float64
     - stdlib/hash
+    - stdlib/immutablemap
     - stdlib/immutablepriorityqueue
+    - stdlib/immutableset
     - stdlib/int32
     - stdlib/int64
     - stdlib/list


### PR DESCRIPTION
I believe these were new in 0..5.4