### PR TITLE
chore: Add ImmutableArray to the sidebar

### DIFF
--- a/docs_config.yml
+++ b/docs_config.yml
@@ -62,6 +62,7 @@ docs_groups:
     - stdlib/float32
     - stdlib/float64
     - stdlib/hash
+    - stdlib/immutablearray
     - stdlib/immutablemap
     - stdlib/immutablepriorityqueue
     - stdlib/immutableset


### PR DESCRIPTION
This adds ImmutableArray (added in 0.5.8) to the sidebar.