### PR TITLE
chore: Upgrade playground to Grain v0.5.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hexo-site",
       "version": "0.0.0",
       "dependencies": {
-        "@grain/stdlib": "0.5.4",
+        "@grain/stdlib": "0.5.8",
         "@wasmer/wasi": "^1.0.2",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@grain/stdlib": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.4.tgz",
-      "integrity": "sha512-mS9oK5e0PEatWfFNUaWeTW2NnomPtQg8EAbPL2MqARNeTjp6Xq8AuxxSBfpKq1m0yQlHrt01OGc2/LKEzu7Lsg==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.8.tgz",
+      "integrity": "sha512-FhCRyOHJh/XuPothSg6u8QEf5Jxr/YskYWuZgVPe7hBnXzoclXihLUp12ot+EfPSXUD9VxZmoZ9MfXCCzakiDg==",
       "engines": {
         "node": ">=16"
       },
@@ -4438,9 +4438,9 @@
       "optional": true
     },
     "@grain/stdlib": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.4.tgz",
-      "integrity": "sha512-mS9oK5e0PEatWfFNUaWeTW2NnomPtQg8EAbPL2MqARNeTjp6Xq8AuxxSBfpKq1m0yQlHrt01OGc2/LKEzu7Lsg=="
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.8.tgz",
+      "integrity": "sha512-FhCRyOHJh/XuPothSg6u8QEf5Jxr/YskYWuZgVPe7hBnXzoclXihLUp12ot+EfPSXUD9VxZmoZ9MfXCCzakiDg=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "npm run cleanup && hexo generate --config docs_config.yml && npm run cleanup && hexo generate --config blog_config.yml && vite build"
   },
   "dependencies": {
-    "@grain/stdlib": "0.5.4",
+    "@grain/stdlib": "0.5.8",
     "@wasmer/wasi": "^1.0.2",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
This updates the playground for Grain v0.5.8

I've tested:

```grain
import Number from "number"

print(Number.parse("1234"))
```

And it seems to work!