### PR TITLE
chore: Update playground for Grain v0.5.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hexo-site",
       "version": "0.0.0",
       "dependencies": {
-        "@grain/stdlib": "0.5.8",
+        "@grain/stdlib": "0.5.9",
         "@wasmer/wasi": "^1.0.2",
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@grain/stdlib": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.8.tgz",
-      "integrity": "sha512-FhCRyOHJh/XuPothSg6u8QEf5Jxr/YskYWuZgVPe7hBnXzoclXihLUp12ot+EfPSXUD9VxZmoZ9MfXCCzakiDg==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.9.tgz",
+      "integrity": "sha512-RIznUo11acHttbsP7pmYtB6sPS9kJCoz1KWEvhp22XAVqPMA0Ef2eIuyCg3WEzc5VZwpw8n2FNrdJMNxzO8WuQ==",
       "engines": {
         "node": ">=16"
       },
@@ -4438,9 +4438,9 @@
       "optional": true
     },
     "@grain/stdlib": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.8.tgz",
-      "integrity": "sha512-FhCRyOHJh/XuPothSg6u8QEf5Jxr/YskYWuZgVPe7hBnXzoclXihLUp12ot+EfPSXUD9VxZmoZ9MfXCCzakiDg=="
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@grain/stdlib/-/stdlib-0.5.9.tgz",
+      "integrity": "sha512-RIznUo11acHttbsP7pmYtB6sPS9kJCoz1KWEvhp22XAVqPMA0Ef2eIuyCg3WEzc5VZwpw8n2FNrdJMNxzO8WuQ=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "npm run cleanup && hexo generate --config docs_config.yml && npm run cleanup && hexo generate --config blog_config.yml && vite build"
   },
   "dependencies": {
-    "@grain/stdlib": "0.5.8",
+    "@grain/stdlib": "0.5.9",
     "@wasmer/wasi": "^1.0.2",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",


### PR DESCRIPTION
This upgrades the playground for v0.5.9 - I didn't test locally, will test on the netlify deploy.