### PR TITLE
chore: Add preview section to installation docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Replace download links
+        # This checks the "grain" prefix so our preview links aren't updated
         run: |
-          sed -E -i 's|(https://github\.com/grain-lang/grain/releases/download/)[^/]+(/)|\1${{ github.event.inputs.tag }}\2|g' src/getting_grain.md
+          sed -E -i 's|(https://github\.com/grain-lang/grain/releases/download/)grain[^/]+(/)|\1foobar\2|g' src/getting_grain.md
 
       - name: Checkout Grain
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Replace download links
         # This checks the "grain" prefix so our preview links aren't updated
         run: |
-          sed -E -i 's|(https://github\.com/grain-lang/grain/releases/download/)grain[^/]+(/)|\1foobar\2|g' src/getting_grain.md
+          sed -E -i 's|(https://github\.com/grain-lang/grain/releases/download/)grain[^/]+(/)|\1${{ github.event.inputs.tag }}\2|g' src/getting_grain.md
 
       - name: Checkout Grain
         uses: actions/checkout@v2

--- a/src/getting_grain.md
+++ b/src/getting_grain.md
@@ -50,6 +50,42 @@ curl -LO https://github.com/grain-lang/grain/releases/download/grain-v0.5.13/gra
 
 You'll either want to put it into your path or keep it inside your project and invoke with `.\grain-win-x64.exe`.
 
+## Previews
+
+We also provide Preview binaries for developers that want to live on the bleeding edge.
+
+**Note:** These are built on almost every commit to our main branch, so they should be considered unstable and the website documentation likely won't match up! Using these binaries successfully requires following the development of Grain closely and/or reviewing our [rolling changelog](https://github.com/grain-lang/grain/pulls?q=is%3Aopen+is%3Apr+label%3A%22autorelease%3A+pending%22).
+
+### MacOS x64 - Preview
+
+You can [download it](https://github.com/grain-lang/grain/releases/download/preview/grain-mac-x64) directly from GitHub or using `curl`.
+
+```sh
+sudo curl -L --output /usr/local/bin/grain \
+https://github.com/grain-lang/grain/releases/download/preview/grain-mac-x64 \
+&& sudo chmod +x /usr/local/bin/grain
+```
+
+### Linux x64 - Preview
+
+You can [download it](https://github.com/grain-lang/grain/releases/download/preview/grain-linux-x64) directly from GitHub or using `curl`.
+
+```sh
+sudo curl -L --output /usr/local/bin/grain \
+https://github.com/grain-lang/grain/releases/download/preview/grain-linux-x64 \
+&& sudo chmod +x /usr/local/bin/grain
+```
+
+### Windows x64 - Preview
+
+You can [download it](https://github.com/grain-lang/grain/releases/download/preview/grain-win-x64.exe) directly from GitHub or using `curl`.
+
+```batch
+curl -LO https://github.com/grain-lang/grain/releases/download/preview/grain-win-x64.exe
+```
+
+You'll either want to put it into your path or keep it inside your project and invoke with `.\grain-win-x64.exe`.
+
 ## Community
 
 These installation methods are maintained by the community—they're not supplied by the Grain team, but you may find them to be useful alternatives to the official distributions.


### PR DESCRIPTION
This adds docs for getting the preview binaries added in https://github.com/grain-lang/grain/pull/1777