### PR TITLE
docs: clarify number type

### DIFF
--- a/src/builtin_types.md
+++ b/src/builtin_types.md
@@ -71,7 +71,7 @@ The type of Grain boxes. Boxes are wrappers that allow the internal data to be s
 type Number
 ```
 
-The type of Grain numbers, i.e. `42`, `0x2a`, `23.19`, `2/3`. Grain numbers can be arbitrarily large integers, floats, or rationals.
+The type of Grain numbers, i.e. `42`, `0x2a`, `23.19`, `2/3`. Grain numbers can be arbitrarily large integers, 64-bit floating-point numbers, or rationals.
 
 ### **BigInt**
 


### PR DESCRIPTION
Specifies that the type of float an object of type number can be is 64-bit floating-point. Because I wondered. 😁