### PR TITLE
Grain Guide - Fix compiler error in "Hello World" example program

### DIFF
--- a/src/guide/hello_world.md
+++ b/src/guide/hello_world.md
@@ -17,6 +17,7 @@ The code for this program is fairly straightforward and should feel familiar fro
 
 ```grain
 // hello.gr
+module Main
 print("Hello, world!")
 ```
 


### PR DESCRIPTION
When attempting to run the "The Code" section of the "Hello World" page on the official Grain guide, I encountered a compiler error message informing me that [paraphrasing] the file was missing a module declaration. I added this extra line of code: (`module Main`) to satiate the compiler warning. It may be appropriate to include a brief overview of the module system here. (The module system is vaguely introduced on the "Data Types" page, towards the end.)

The guide is a great read thus far, concise and well-paced. 
Thank you for your review. 