### PR TITLE
Add `.wast` output to Grain Playground

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@grain/stdlib": "0.5.13",
         "@wasmer/wasi": "^1.0.2",
         "assert": "^2.0.0",
+        "binaryen": "^116.0.0",
         "buffer": "^6.0.3",
         "constants-browserify": "^1.0.0",
         "events": "^3.3.0",
@@ -359,6 +360,15 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/binaryen": {
+      "version": "116.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-116.0.0.tgz",
+      "integrity": "sha512-Hp0dXC6Cb/rTwWEoUS2BRghObE7g/S9umKtxuTDt3f61G6fNTE/YVew/ezyy3IdHcLx3f17qfh6LwETgCfvWkQ==",
+      "bin": {
+        "wasm-opt": "bin/wasm-opt",
+        "wasm2js": "bin/wasm2js"
       }
     },
     "node_modules/bluebird": {
@@ -4599,6 +4609,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
+    },
+    "binaryen": {
+      "version": "116.0.0",
+      "resolved": "https://registry.npmjs.org/binaryen/-/binaryen-116.0.0.tgz",
+      "integrity": "sha512-Hp0dXC6Cb/rTwWEoUS2BRghObE7g/S9umKtxuTDt3f61G6fNTE/YVew/ezyy3IdHcLx3f17qfh6LwETgCfvWkQ=="
     },
     "bluebird": {
       "version": "3.5.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@grain/stdlib": "0.5.13",
     "@wasmer/wasi": "^1.0.2",
     "assert": "^2.0.0",
+    "binaryen": "^116.0.0",
     "buffer": "^6.0.3",
     "constants-browserify": "^1.0.0",
     "events": "^3.3.0",

--- a/playground_src/index.html
+++ b/playground_src/index.html
@@ -85,5 +85,8 @@
             <pre id="output"></pre>
             <button id="run">Compile &amp; Run <i class="fas fa-play"></i></button>
         </section>
+        <section id="wast-panel">
+            <pre id="wast"></pre>
+        </section>
     </div>
 </body>

--- a/playground_src/index.html
+++ b/playground_src/index.html
@@ -84,6 +84,12 @@
         <section id="output-panel">
             <pre id="output"></pre>
             <button id="run">Compile &amp; Run <i class="fas fa-play"></i></button>
+            <form>
+                <label>
+                    Show Wasm text format
+                    <input id="show-wast-checkbox" type="checkbox">
+                </label>
+            </form>
         </section>
         <section id="wast-panel">
             <pre id="wast"></pre>

--- a/playground_src/scripts/compiler.js
+++ b/playground_src/scripts/compiler.js
@@ -88,6 +88,8 @@ addEventListener("message", async ({ data }) => {
           args: [],
         });
         const binaryenModule = binaryen.readBinary(wasm);
+        binaryenModule.setFeatures(binaryen.Features.All);
+        binaryenModule.optimize();
         const wast = binaryenModule.emitText();
         const module = await WebAssembly.compile(wasm);
         await wasi.instantiate(module, {});

--- a/playground_src/scripts/editor.js
+++ b/playground_src/scripts/editor.js
@@ -109,7 +109,7 @@ export async function createGrainEditor(id, value) {
   return createConfiguredEditor(document.getElementById(id), {
     language: "grain",
     value,
-    automaticLayout: true,
+    automaticLayout: false,
     minimap: {
       enabled: false,
     },

--- a/playground_src/scripts/playground.js
+++ b/playground_src/scripts/playground.js
@@ -30,9 +30,11 @@ async function start() {
     if (showWastCheckbox.checked) {
       editorWrapper.style.gridTemplateColumns = "2fr 1fr 1fr";
       wastPanel.style.display = "flex";
+      runButton.click();
       return;
     }
     editorWrapper.style.gridTemplateColumns = "2fr 1fr";
+    wastPanel.querySelector('pre').innerText = "";
     wastPanel.style.display = "none";
   };
   showWastCheckbox.addEventListener("change", onShowWastCheckboxChange);

--- a/playground_src/scripts/playground.js
+++ b/playground_src/scripts/playground.js
@@ -20,9 +20,23 @@ async function start() {
   const editor = await createGrainEditor("editor", 'print("hello world")\n');
 
   const outputPanel = document.getElementById("output-panel");
-  const wastPanel = document.getElementById("wast");
+  const wastPanel = document.getElementById("wast-panel");
   const output = document.getElementById("output");
   const runButton = document.getElementById("run");
+  const showWastCheckbox = document.getElementById("show-wast-checkbox");
+  const editorWrapper = document.getElementById("editor-wrapper");
+
+  const onShowWastCheckboxChange = () => {
+    if (showWastCheckbox.checked) {
+      editorWrapper.style.gridTemplateColumns = "2fr 1fr 1fr";
+      wastPanel.style.display = "flex";
+      return;
+    }
+    editorWrapper.style.gridTemplateColumns = "2fr 1fr";
+    wastPanel.style.display = "none";
+  };
+  showWastCheckbox.addEventListener("change", onShowWastCheckboxChange);
+  onShowWastCheckboxChange();
 
   window.addEventListener("resize", debounce(
    () => {
@@ -37,10 +51,11 @@ async function start() {
     runButton.disabled = true;
     outputPanel.style.backgroundColor = "#EFEFEF";
     output.innerText = "Compiling...";
-    wastPanel.innerText = "";
+    wastPanel.querySelector('pre').innerText = "";
 
     worker.postMessage({
       content: editor.getValue(),
+      showWast: showWastCheckbox.checked,
     });
 
     worker.onmessage = ({ data }) => {
@@ -58,7 +73,7 @@ async function start() {
       } else {
         output.innerText = "< no program output >";
       }
-      wastPanel.innerText = data?.wast || "";
+      wastPanel.querySelector('pre').innerText = data?.wast || "";
     };
 
     worker.onerror = (err) => {

--- a/playground_src/scripts/playground.js
+++ b/playground_src/scripts/playground.js
@@ -3,18 +3,41 @@ import CompilerWorker from "./compiler?worker";
 const worker = new CompilerWorker();
 worker.onerror = (err) => console.error(err);
 
+const debounce = (func, wait) => {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+};
+
 async function start() {
   const { createGrainEditor } = await import("./editor");
   const editor = await createGrainEditor("editor", 'print("hello world")\n');
 
   const outputPanel = document.getElementById("output-panel");
+  const wastPanel = document.getElementById("wast");
   const output = document.getElementById("output");
   const runButton = document.getElementById("run");
+
+  window.addEventListener("resize", debounce(
+   () => {
+    const isThreeColumnLayout = document.body.clientWidth >= 1024;
+    editor.layout({
+      width: isThreeColumnLayout ? Math.floor(document.body.clientWidth / 2) : document.body.clientWidth,
+      height: editor.getContentHeight()
+    });
+  }, 100));
 
   runButton.onclick = function compile() {
     runButton.disabled = true;
     outputPanel.style.backgroundColor = "#EFEFEF";
     output.innerText = "Compiling...";
+    wastPanel.innerText = "";
 
     worker.postMessage({
       content: editor.getValue(),
@@ -35,11 +58,14 @@ async function start() {
       } else {
         output.innerText = "< no program output >";
       }
+      wastPanel.innerText = data?.wast || "";
     };
 
     worker.onerror = (err) => {
       console.error(err);
     };
+
+    editor.layout();
   };
 }
 

--- a/playground_src/stylesheets/playground.css
+++ b/playground_src/stylesheets/playground.css
@@ -41,9 +41,14 @@ body {
     background-color: var(--gray2);
 }
 
+form {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
 #editor-wrapper {
     display: grid;
-    grid-template-columns: 2fr 1fr 1fr;
+    grid-template-columns: 2fr 1fr;
 }
 
 #output-panel {
@@ -53,6 +58,7 @@ body {
 }
 
 #wast-panel {
+    display: none;
     background-color: var(--gray2);
     height: calc(100vh - var(--nav-height) - var(--grid-gap));
     overflow: auto;

--- a/playground_src/stylesheets/playground.css
+++ b/playground_src/stylesheets/playground.css
@@ -1,13 +1,15 @@
-body {
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
+:root {
+    --nav-height: 8rem;
+    --grid-gap: 0.5rem;
 }
-
-#toolbar {
-    display: flex;
-    flex-direction: column;
-    background-color: var(--gray);
+body {
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+    max-height: 100vh;
+    display: grid;
+    gap: var(--grid-gap);
+    grid-template-rows: var(--nav-height) 1fr;
 }
 
 #run {
@@ -40,34 +42,36 @@ body {
 }
 
 #editor-wrapper {
-    flex: 1;
-    display: flex;
-    flex-direction: row;
-}
-
-#editor {
-    flex: 3;
-}
-.monaco-editor {
-    padding-top: 1rem;
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr;
 }
 
 #output-panel {
-    flex: 1;
     background-color: var(--gray);
     display: flex;
     flex-direction: column;
 }
 
-#output {
+#wast-panel {
+    background-color: var(--gray2);
+    height: calc(100vh - var(--nav-height) - var(--grid-gap));
+    overflow: auto;
+}
+
+#output,
+#wast {
+    flex-grow: 1;
     padding: 1rem;
     margin: 0;
-    flex-grow: 1;
     white-space: pre-wrap;
 }
 
-@media only screen and (max-width: 768px) {
+@media only screen and (max-width: 1024px) {
     #editor-wrapper {
-        flex-direction: column;
+        grid-template-columns: 1fr;
+        grid-template-rows: 33% 33% 33%;
+    }
+    #editor {
+        height: calc(100% / 3);
     }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,7 +24,7 @@ module.exports = ({ mode }) => {
     },
     optimizeDeps: {
       esbuildOptions: {
-        target: "es2020",
+        target: "esnext",
         define: {
           global: "globalThis",
           process: JSON.stringify({}),


### PR DESCRIPTION
This PR makes the following improvements:

- Adds `.wast` output to the playground.
- Improves mobile and desktop layout.

Screenshots:

- Desktop:
   ![Screenshot 2024-01-29 at 15 55 37](https://github.com/grain-lang/grain-lang.org/assets/145676/a21a0a67-b0a9-4d99-ad24-4a13c95d667b)
- Mobile:
   ![Screenshot 2024-01-29 at 15 57 36](https://github.com/grain-lang/grain-lang.org/assets/145676/8c7c62a6-1f84-47b4-acfb-4c7a03b9c2ff)
