### PR TITLE
chore: Update binary build time in the guide

### DIFF
--- a/src/getting_grain.md
+++ b/src/getting_grain.md
@@ -8,7 +8,7 @@ We have a couple different ways to get Grain. Most developers will prefer the Pa
 
 The Grain toolchain (including our CLI, compiler, runtime, and standard library) is shipped as a single binary. Binaries are available for [MacOS x64](#MacOS-x64---Homebrew), [Linux x64](#Linux-x64---Download), and [Windows x64](#Windows-x64---Download).
 
-**Note:** These binaries are a bit slow when first building a project (around 70 seconds). The packaged compiler is running in JavaScript, _and_ it builds and writes the runtime & standard library into your project. If you need raw speed, you can build the native compiler from source! See [Building Grain from Source](#Building-Grain-from-Source) below.
+**Note:** These binaries are a bit slow when first building a project (around 10 seconds). The packaged compiler is running in JavaScript, _and_ it builds and writes the runtime & standard library into your project. If you need raw speed, you can build the native compiler from source! See [Building Grain from Source](#Building-Grain-from-Source) below.
 
 ### MacOS x64 - Homebrew
 


### PR DESCRIPTION
The binaries are much faster as of 0.6.