### PR TITLE
chore: Remove DOM docs

### DIFF
--- a/docs_config.yml
+++ b/docs_config.yml
@@ -59,7 +59,6 @@ docs_groups:
     - stdlib/buffer
     - stdlib/bytes
     - stdlib/char
-    - stdlib/DOM
     - stdlib/exception
     - stdlib/float32
     - stdlib/float64

--- a/src/stdlib/DOM.md
+++ b/src/stdlib/DOM.md
@@ -1,9 +1,0 @@
----
-title: DOM
----
-
-Utilities for working with the browser's Document Object Model.
-
-## Progress
-
-This module is [currently being rewritten](https://github.com/grain-lang/grain/issues/126). Once complete, this documentation will be updated. If this module is important to you, let us know or get involved!


### PR DESCRIPTION
It will be some time before we offer this capability as a part of the standard library, so removing it for now.