### PR TITLE
feat: Backport doc improvements for `0.7`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2
 
+      - name: Clean previous docs
+        run: |
+          rm -rf ./src/stdlib/*/
+          rm -rf ./src/stdlib/*.md
+
       - name: Replace download links
         # This checks the "grain" prefix so our preview links aren't updated
         run: |

--- a/src/builtin_types.md
+++ b/src/builtin_types.md
@@ -102,6 +102,17 @@ type Rational
 
 The type of Grain rationals, e.g. `2/3r`. Rationals are represented as a numerator and denominator.
 
+### **Range**
+
+```grain
+record Range<a> {
+  rangeStart: a,
+  rangeEnd: a
+}
+```
+
+A range of values, with a start and end value.
+
 ### **Number**
 
 ```grain

--- a/src/getting_grain.md
+++ b/src/getting_grain.md
@@ -110,7 +110,7 @@ See the [plugin](https://github.com/cometkim/asdf-grain) for more details.
 
 To get access to the entirely native compiler, you can build Grain from source.
 
-First, you'll need [Node.js](https://nodejs.org/en/download/current/) v16.
+First, you'll need [Node.js](https://nodejs.org/en/download/current/) v22.
 
 Start by cloning the Grain repository:
 

--- a/src/guide/collections_and_libraries.md
+++ b/src/guide/collections_and_libraries.md
@@ -115,7 +115,9 @@ In some cases, this could allow us to write programs that are more efficient tha
 However, the size of an array is fixed. To add additonal items to an array, we must append them together, which would create a brand new, third array:
 
 ```grain
-import Array from "array"
+module Main
+
+from "array" include Array
 
 let one = [> 1]
 let twoThree = [> 2, 3]

--- a/src/guide/loops.md
+++ b/src/guide/loops.md
@@ -53,7 +53,7 @@ while (true) {
 ```grain
 module Main
 
-import Array from "array"
+from "array" include Array
 
 let strings = [> "foo", "bar", "baz"]
 

--- a/src/guide/mutation.md
+++ b/src/guide/mutation.md
@@ -71,7 +71,7 @@ It is also possible to create a binding with the same name as an existing bindin
 module Main
 
 let val = 1
-let val = 2 // `val` now refers a new value
+let val = 2 // `val` now refers to a new value
 ```
 
 It is important to note that shadowing does not modify what the shadowed binding refers to, but rather makes a new association for a binding name within the scope:

--- a/src/index.md
+++ b/src/index.md
@@ -11,3 +11,7 @@ Grain is a programming language that brings wonderful features from academic and
 ## The WebAssembly Bits
 
 One of the most exciting things about Grain is that it compiles to WebAssembly. As such, Grain can run in the browser, on your computer, on a server, and potentially elsewhere. This guide will largely focus on the browser and terminal.
+
+## Getting additional help
+
+If something isn't making sense or you have more questions, reach out in the `#support` channel on the [Grain Discord server](https://discord.com/invite/grain-lang). There are a bunch of friendly folks happy to help out!

--- a/src/tooling/grain_cli.md
+++ b/src/tooling/grain_cli.md
@@ -25,13 +25,14 @@ All of the supported flags can be found below:
 | Flag                          | Description                                                                 |
 | ----------------------------- | --------------------------------------------------------------------------- |
 | -I, --include-dirs <dirs>     | add additional dependency include directories                               |
-| -S, --stdlib <path>           | override the standard libary with your own                                  |
+| -S, --stdlib <path>           | override the standard library with your own                                 |
+| -o <filename>                 | output filename                                                             |
 | --initial-memory-pages <size> | initial number of WebAssembly memory pages                                  |
 | --maximum-memory-pages <size> | maximum number of WebAssembly memory pages                                  |
-| --compilation-mode <mode>     | compilation mode (advanced use only)                                        |
+| --import-memory               | import the memory from `env.memory`                                         |
 | --elide-type-info             | don't include runtime type information used by toString/print               |
 | --release                     | compile using the release profile (production mode)                         |
-| --experimental-wasm-tail-call | enables tail-call optimization                                              |
+| --no-wasm-tail-call           | disables tail-call optimization                                             |
 | --debug                       | compile with debugging information                                          |
 | --wat                         | additionally produce a WebAssembly Text (.wat) file                         |
 | --hide-locs                   | hide locations from intermediate trees. Only has an effect with `--verbose` |
@@ -40,9 +41,9 @@ All of the supported flags can be found below:
 | --no-bulk-memory              | polyfill WebAssembly bulk memory instructions                               |
 | --wasi-polyfill <filename>    | path to custom WASI implementation                                          |
 | --use-start-section           | replaces the \_start export with a start section during linking             |
+| --single-file                 | compile a single file without compiling                                     |
 | --no-link                     | disable static linking                                                      |
 | --no-pervasives               | don't automatically import the Grain Pervasives module                      |
-| --parser-debug-level <level>  | debugging level for parser output                                           |
 | --memory-base <addr>          | set the base address for the Grain heap                                     |
 | --source-map                  | generate source maps                                                        |
 | --strict-sequence             | enable strict sequencing                                                    |
@@ -51,7 +52,7 @@ All of the supported flags can be found below:
 
 ## `grain run`
 
-Runs a WebAssembly file. The `grain run` command can run Grain programs compiled with `--no-link`, and can also run WebAssembly files produced by other compilers.
+Runs a WebAssembly file. The `grain run` command can also run WebAssembly files produced by other compilers.
 
 ```sh
 grain run hello.gr.wasm


### PR DESCRIPTION
As we have decided to hold the new website for a little bit, I figured it would make sense to backport a few of the documentation improvements and fixes to the current version.

Changes:
* On Release we now clean the `stdlib` docs
  * This gets rid of removed modules `ImmutableMap`
* Add the missing `Range` datatype
* Mention node `v22` over `v16` as we're upgrading
* Correct some `0.5` syntax that was missed
* Update the cli options table

One additional note is the `asdf` release still points to `0.4.6` but I'm waiting until we decide how to handle it with the v2 version before updating (Our release process won't update that). 

This is on hold until the next release because of the `v22` note.